### PR TITLE
Use POSIX_FADV_DONTNEED after pread to reduce cache pollution

### DIFF
--- a/bdsync.c
+++ b/bdsync.c
@@ -363,6 +363,9 @@ int vpread (int devfd, void *buf, off_t len, off_t pos, off_t devsize)
         if (ret < 0) exitmsg (exitcode_read_error, "vpread: %s\n", strerror (errno));
     }
 
+    //Use fadvise to release buffer/cache
+    posix_fadvise (devfd, pos, rlen, POSIX_FADV_DONTNEED);
+
     if (rlen < len) memset (cbuf + rlen, 0, len - rlen);
 
     return ret;
@@ -2135,6 +2138,7 @@ enum exitcode do_patch (char *dev, int warndev, int diffsize)
             verbose (0, "Write error: pos=%lld len=%d\n", (long long)pos, blen);
             exit (exitcode_write_error);
         }
+        posix_fadvise(devfd, pos, blen, POSIX_FADV_DONTNEED);
     }
 
     {

--- a/bdsync.c
+++ b/bdsync.c
@@ -2138,7 +2138,6 @@ enum exitcode do_patch (char *dev, int warndev, int diffsize)
             verbose (0, "Write error: pos=%lld len=%d\n", (long long)pos, blen);
             exit (exitcode_write_error);
         }
-        posix_fadvise(devfd, pos, blen, POSIX_FADV_DONTNEED);
     }
 
     {


### PR DESCRIPTION
Reading large file (for comparison) uselessy pollute buffer/cache memory. This patch greatly decreases cache pollution by calling POSIX_FADV_DONTNEED after each `pread` (in `vpread` function).

This is a better solution as opening the file/dev with `O_DIRECT` flag because direct access has alignment restriction on both source (file/dev) and destination (application buffer). Moreover, it is quite portable and should have no problem with filesystem without `O_DIRECT` semantic.